### PR TITLE
Returning samples on GPU with VonMisesFisher and HypersphericalUniform distributions.

### DIFF
--- a/hyperspherical_vae/distributions/von_mises_fisher.py
+++ b/hyperspherical_vae/distributions/von_mises_fisher.py
@@ -27,9 +27,9 @@ class VonMisesFisher(torch.distributions.Distribution):
         self.loc = loc
         self.scale = scale
         self.device = loc.device
-        self.__m =  loc.shape[-1]
+        self.__m = loc.shape[-1]
         self.__e1 = (torch.Tensor([1.] + [0] * (loc.shape[-1] - 1))).to(self.device)
-        
+
         super(VonMisesFisher, self).__init__(self.loc.size(), validate_args=validate_args)
 
     def sample(self, shape=torch.Size()):
@@ -38,18 +38,18 @@ class VonMisesFisher(torch.distributions.Distribution):
 
     def rsample(self, shape=torch.Size()):
         shape = shape if isinstance(shape, torch.Size) else torch.Size([shape])
-        
+
         w = self.__sample_w3(shape=shape) if self.__m == 3 else self.__sample_w_rej(shape=shape)
-        
+
         v = (torch.distributions.Normal(0, 1).sample(
             shape + torch.Size(self.loc.shape)).to(self.device).transpose(0, -1)[1:]).transpose(0, -1)
         v = v / v.norm(dim=-1, keepdim=True)
-        
+
         x = torch.cat((w, torch.sqrt(1 - (w ** 2)) * v), -1)
         z = self.__householder_rotation(x)
 
         return z.type(self.dtype)
-    
+
     def __sample_w3(self, shape):
         shape = shape + torch.Size(self.scale.shape)
         u = torch.distributions.Uniform(0, 1).sample(shape).to(self.device)
@@ -59,11 +59,12 @@ class VonMisesFisher(torch.distributions.Distribution):
     def __sample_w_rej(self, shape):
         c = torch.sqrt((4 * (self.scale ** 2)) + (self.__m - 1) ** 2)
         b_true = (-2 * self.scale + c) / (self.__m - 1)
-        
+
         # using Taylor approximation with a smooth swift from 10 < scale < 11
         # to avoid numerical errors for large scale
         b_app = (self.__m - 1) / (4 * self.scale)
-        s = torch.min(torch.max(torch.Tensor([0.]), self.scale - 10), torch.Tensor([1.]))
+        s = torch.min(torch.max(torch.tensor([0.], device=self.device),
+                                self.scale - 10), torch.tensor([1.], device=self.device))
         b = b_app * s + b_true * (1 - s)
 
         a = (self.__m - 1 + 2 * self.scale + c) / 4
@@ -71,42 +72,44 @@ class VonMisesFisher(torch.distributions.Distribution):
 
         self.__b, (self.__e, self.__w) = b, self.__while_loop(b, a, d, shape)
         return self.__w
-    
+
     def __while_loop(self, b, a, d, shape):
-        
+
         b, a, d = [e.repeat(*shape, *([1] * len(self.scale.shape))) for e in (b, a, d)]
-        w, e, bool_mask = torch.zeros_like(b).to(self.device), torch.zeros_like(b).to(self.device), (torch.ones_like(b) == 1).to(self.device)
-        
+        w, e, bool_mask = torch.zeros_like(b).to(self.device), torch.zeros_like(
+            b).to(self.device), (torch.ones_like(b) == 1).to(self.device)
+
         shape = shape + torch.Size(self.scale.shape)
- 
+
         while bool_mask.sum() != 0:
-            e_ = torch.distributions.Beta((self.__m - 1) / 2, (self.__m - 1) / 2).sample(shape[:-1]).reshape(shape).to(self.device)
+            e_ = torch.distributions.Beta((self.__m - 1) / 2, (self.__m - 1) /
+                                          2).sample(shape[:-1]).reshape(shape).to(self.device)
             u = torch.distributions.Uniform(0, 1).sample(shape).to(self.device)
-            
+
             w_ = (1 - (1 + b) * e_) / (1 - (1 - b) * e_)
             t = (2 * a * b) / (1 - (1 - b) * e_)
 
             accept = ((self.__m - 1) * t.log() - t + d) > torch.log(u)
             reject = 1 - accept
-            
+
             w[bool_mask * accept] = w_[bool_mask * accept]
             e[bool_mask * accept] = e_[bool_mask * accept]
 
             bool_mask[bool_mask * accept] = reject[bool_mask * accept]
-        
+
         return e, w
-    
+
     def __householder_rotation(self, x):
         u = (self.__e1 - self.loc)
         u = u / (u.norm(dim=-1, keepdim=True) + 1e-5)
         z = x - 2 * (x * u).sum(-1, keepdim=True) * u
         return z
-    
+
     def entropy(self):
         output = - self.scale * ive(self.__m / 2, self.scale) / ive((self.__m / 2) - 1, self.scale)
-        
+
         return output.view(*(output.shape[:-1])) + self._log_normalization()
-        
+
     def log_prob(self, x):
         return self._log_unnormalized_prob(x) - self._log_normalization()
 
@@ -117,7 +120,7 @@ class VonMisesFisher(torch.distributions.Distribution):
 
     def _log_normalization(self):
         output = - ((self.__m / 2 - 1) * torch.log(self.scale) - (self.__m / 2) * math.log(2 * math.pi) - (
-                self.scale + torch.log(ive(self.__m / 2 - 1, self.scale))))
+            self.scale + torch.log(ive(self.__m / 2 - 1, self.scale))))
 
         return output.view(*(output.shape[:-1]))
 


### PR DESCRIPTION
This pull request proposes the following:

**fix**. The VonMisesFisher distribution throws an error in `_sample_w_rej()`  (line 66) when `scale` and `location` are provided as Cuda tensors. This is solved by adding the `device` argument to tensor creation. 
**enhancement**. The HypersphericalUniform distribution had no way of returning samples on the GPU. This is now possible by providing a device to the `device` argument in `__init__()`.
