### PR TITLE
Fixes logical negation usage error with PyTorch > 1.2.0

### DIFF
--- a/hyperspherical_vae/distributions/von_mises_fisher.py
+++ b/hyperspherical_vae/distributions/von_mises_fisher.py
@@ -91,7 +91,7 @@ class VonMisesFisher(torch.distributions.Distribution):
             t = (2 * a * b) / (1 - (1 - b) * e_)
 
             accept = ((self.__m - 1) * t.log() - t + d) > torch.log(u)
-            reject = 1 - accept
+            reject = ~accept if torch.__version__ >= "1.2.0" else 1 - accept
 
             w[bool_mask * accept] = w_[bool_mask * accept]
             e[bool_mask * accept] = e_[bool_mask * accept]


### PR DESCRIPTION
The acceptance expression in VonMisesFisher.__while_loop() used to return
an integer tensor prior to PyTorch 1.2.0, but is now a ByteTensor. To negate
it one must use the logical not operator ('~').

Tested with PyTorch 1.3.1.